### PR TITLE
Add simple S3 integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -584,6 +584,49 @@
         }
       }
     },
+    "aws-sdk": {
+      "version": "2.218.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.218.1.tgz",
+      "integrity": "sha1-tM90LMCFO9fIaLOIy/C0oe8avBI=",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1567,8 +1610,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-      "dev": true
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "basic-auth": {
       "version": "2.0.0",
@@ -1909,7 +1951,6 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
       "requires": {
         "base64-js": "1.2.1",
         "ieee754": "1.1.8",
@@ -5944,8 +5985,7 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
       "version": "3.3.7",
@@ -6506,7 +6546,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -7609,6 +7649,11 @@
       "requires": {
         "merge-stream": "1.0.1"
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-base64": {
       "version": "2.3.2",
@@ -11364,8 +11409,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -12296,8 +12340,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "0.3.0",
@@ -14778,9 +14821,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-url": {
       "version": "6.4.0",
@@ -14905,6 +14948,23 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "4.2.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "author": "gccdev",
   "license": "ISC",
   "dependencies": {
+    "aws-sdk": "^2.218.1",
     "bluebird": "^3.5.0",
     "body-parser": "^1.18.2",
     "bootstrap": "^4.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -5,12 +5,15 @@ const nconf = require('nconf');
 const mockConfig = {
   GOOGLE_MAPS_KEY: 'GOOGLE_MAPS_KEY',
   COOKIE_SECRET: 'COOKIE_SECRET',
+  MONGODB_URI: 'mongodb://localhost:27017/gccweb_test',
 };
 
 // secret config needed for testing
 const secretConfig = {
   GOOGLE_CLIENT_ID: 'GOOGLE_CLIENT_ID',
   GOOGLE_CLIENT_SECRET: 'GOOGLE_CLIENT_SECRET',
+  AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID',
+  AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY',
 };
 
 const defaultConfig = {
@@ -20,6 +23,8 @@ const defaultConfig = {
   PUBLIC_SERVER_HOST: 'localhost:8080',
   ADMIN_SERVER_HOST: 'localhost:8081',
   MONGODB_URI: 'mongodb://localhost:27017/gccweb',
+  AWS_REGION: 'us-east-1',
+  AWS_ASSET_BUCKET: 's3.web.staging',
 };
 
 nconf

--- a/src/models/helpers/aws.js
+++ b/src/models/helpers/aws.js
@@ -1,0 +1,23 @@
+import AWS from 'aws-sdk';
+import nconf from '../../config';
+
+AWS.config.update({
+  region: nconf.get('AWS_REGION'),
+  accessKeyId: nconf.get('AWS_ACCESS_KEY_ID'),
+  secretAccessKey: nconf.get('AWS_SECRET_ACCESS_KEY'),
+});
+
+/**
+ * Gets an AWS.S3 bucket object
+ * @param {string} bucket - The name of the S3 bucket
+ * @returns {AWS.S3}
+ */
+export function s3Bucket(bucket) {
+  return new AWS.S3({
+    params: {
+      Bucket: bucket,
+    },
+  });
+}
+
+export default AWS;

--- a/src/models/s3resource.js
+++ b/src/models/s3resource.js
@@ -1,0 +1,85 @@
+import mongoose from 'mongoose';
+import { s3Bucket } from './helpers/aws';
+
+/**
+ * The S3 resource schema used by mongoose
+ * @type {mongoose.Schema}
+ */
+export const S3ResourceSchema = mongoose.Schema({
+  bucket: {
+    type: String,
+    required: true,
+    index: true,
+  },
+  key: {
+    type: String,
+    required: true,
+    index: true,
+  },
+  fileUrl: {
+    type: String,
+    required: true,
+  },
+});
+
+/**
+ * Upload a resource to an S3 bucket
+ * @param {string} bucket - The S3 bucket
+ * @param {string} key - The key to name the object
+ * @param {Buffer|Typed Array|Blob|String|ReadableStream} data - The data to upload
+ * @param {Object} params - Additional parameters @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+ * @param {function(loaded: number, total:number)} [uploadProgress] -
+ *   Callback function to report upload progress
+ * @returns {Promise<S3Resource, Error>} -
+ *   Returns a promise which resolves to the uploaded resource or rejects with an Error
+ */
+function S3ResourceUpload(bucket, key, data, params = {}, uploadProgress) {
+  let managedUpload = s3Bucket(bucket).upload(Object.assign({}, params, {
+    Key: key,
+    Body: data,
+  }));
+
+  if (uploadProgress) {
+    managedUpload = managedUpload.on('httpUploadProgress', uploadProgress);
+  }
+
+  return managedUpload.promise().then(({ Location: fileUrl }) => (
+    this.findOneAndUpdate({ bucket, key }, { fileUrl }, {
+      upsert: true,
+      new: true,
+      setDefaultsOnInsert: true,
+    })
+  ));
+}
+
+/**
+ * Function executed before removing the decoument
+ * @param {function} next - The next function for Express
+ * @returns {void}
+ */
+function preRemoveHook(next) {
+  s3Bucket(this.bucket).deleteObject({ Key: this.key }, next);
+}
+
+/**
+ * Function executed before finding and removing the decoument
+ * @param {function} next - The next function for Express
+ * @returns {void}
+ */
+function preFindOneAndRemoveHook(next) {
+  this.model.findOne(this.getQuery()).then((resource) => {
+    s3Bucket(resource.bucket).deleteObject({ Key: resource.key }, next);
+  }).catch(err => next(err));
+}
+
+S3ResourceSchema.statics.Upload = S3ResourceUpload;
+S3ResourceSchema.pre('remove', preRemoveHook);
+S3ResourceSchema.pre('findOneAndRemove', preFindOneAndRemoveHook);
+
+/**
+ * A model object for S3 resources
+ * @type {mongoose.Model}
+ */
+const S3Resource = mongoose.model('S3Resource', S3ResourceSchema);
+
+export default S3Resource;

--- a/src/models/s3resource.test.js
+++ b/src/models/s3resource.test.js
@@ -1,0 +1,34 @@
+/* eslint-env node, jest */
+
+import fetch from 'isomorphic-fetch';
+import { withDB } from '../../test/dbSetup';
+import { itPrivate } from '../../test/env';
+import nconf from '../../src/config';
+import S3Resource from './s3resource';
+
+describe('S3Resource', () => {
+  withDB();
+
+  itPrivate('uploads and destroys', () => {
+    const data = [...new Array(10)].map(() => Math.random()).join('');
+    return S3Resource.Upload(
+      nconf.get('AWS_ASSET_BUCKET'),
+      's3resource-uploads-and-destroys',
+      data, {
+        ACL: 'public-read',
+        ContentType: 'text',
+      },
+    ).then((s3Resource) => {
+      const { fileUrl } = s3Resource;
+      return fetch(fileUrl).then((response) => {
+        if (response.status >= 400) {
+          throw new Error(`Failed to fetch test file. ${response.statusText}`);
+        }
+        return response.text();
+      }).then((text) => {
+        expect(text).toBe(data);
+        return s3Resource.remove();
+      });
+    });
+  });
+});

--- a/test/dbSetup.js
+++ b/test/dbSetup.js
@@ -1,0 +1,23 @@
+/* eslint-env node, jest */
+import mongoose from 'mongoose';
+import nconf from '../src/config';
+
+export function withDB() {
+  let db = null;
+
+  beforeAll(() => (
+    new Promise((resolve, reject) => {
+      db = mongoose.connect(nconf.get('MONGODB_URI'), { useMongoClient: true }, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(db);
+        }
+      });
+    })
+  ));
+
+  afterAll(() => {
+    db && db.close();
+  });
+}

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,5 @@
+/* eslint-env node, jest */
+import nconf from '../src/config';
+
+export const itPrivate = nconf.get('TRAVIS_PULL_REQUEST') ? it.skip : it;
+export const describePrivate = nconf.get('TRAVIS_PULL_REQUEST') ? describe.skip : describe;


### PR DESCRIPTION
Some baby steps toward S3 integration.

- Creates an `S3Resource` mongoose model which in the future can be referenced by other database entires for images, sermons, etc.
- `S3Resource.Upload` and deleting the database object wrap `aws-sdk` to handle uploading and removing the file from S3.
- Adds testing setup to connect to the Mongo database before tests are run and disconnect after.
- Adds a test to ensure that upload works, the data is exactly as expected, and removal works
- Adds `itPrivate` and `describePrivate` in `test/env.js`. These are conditionally `it.skip` and `it` depending on the testing environment. This is important because for **pull requests** (which anyone can submit) we clobber our secret environment variables with dummy variables so a random stranger doesn't steal our keys. In these situations, tests which use important secret keys simply won't work. `itPrivate` and `describePrivate` will allow us to run those tests only on code that a maintainer has reviewed and approved.