### PR TITLE
Remove ministries grid, use cards

### DIFF
--- a/src/client/pages/Ministries.css
+++ b/src/client/pages/Ministries.css
@@ -1,30 +1,6 @@
 #ministries{
 	.pageContent{
-		display: grid;
-		grid-column-gap: 5%;
-		grid-row-gap: 50px;
-		margin: 50px 10%;
-		text-align: center;
-		
-		grid-template-columns: 1fr;
-
-		@media(min-width: 600px){
-			grid-template-columns: 1fr 1fr;
-		}
-
-		@media(min-width: 900px){
-			grid-template-columns: 1fr 1fr 1fr;
-		}
-	}
-
-	.ministryBox{
-		background: #E3E3E3;
-		width: 100%;
-		height: 300px;
-
-		&:hover{
-			background: #D3D3D3;
-			cursor: pointer;
-		}
-	}
+		padding: 60px;
+		text-align: center;	
+	}	
 }

--- a/src/client/pages/Ministries.jsx
+++ b/src/client/pages/Ministries.jsx
@@ -7,12 +7,87 @@ import Helmet from 'react-helmet';
 import pluralize from 'pluralize';
 
 import withTitle from '../hoc/withTitle';
-import Center from '../components/Center';
 import TitleBanner from '../components/TitleBanner';
 import { fetchModelData } from '../modules/modelData';
-
+import TileDeck from '../components/TileDeck';
 
 import styles from './Ministries.css';
+
+// TODO: update descriptions with proper text
+const ministriesList = [
+  {
+    image: '/static/images/ministries/icons/diakonos.png',
+    imageTitle: 'diakonos',
+    title: 'Diakonos',
+    description: 'We believe the Bible, both the Old and New Testaments, is the only inspired, infallible, and authoritative Word of God. It is the supreme source of truth for Christian faith and living.',
+  },
+  {
+    image: '/static/images/ministries/icons/evangelism.png',
+    imageTitle: 'evangelism',
+    title: 'Evangelism',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/finance.png',
+    imageTitle: 'finance',
+    title: 'Finance',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/graphics.png',
+    imageTitle: 'graphics',
+    title: 'Graphics',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/hospitality.png',
+    imageTitle: 'hospitality',
+    title: 'Hospitality',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/missions.png',
+    imageTitle: 'missions',
+    title: 'Missions',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/multimedia.png',
+    imageTitle: 'multimedia',
+    title: 'Multimedia',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/overflow.png',
+    imageTitle: 'overflow',
+    title: 'Overflow',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/transportation.png',
+    imageTitle: 'transportation',
+    title: 'Transportation',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/web.png',
+    imageTitle: 'web',
+    title: 'Web',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/welcoming.png',
+    imageTitle: 'welcoming',
+    title: 'Welcoming',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+  {
+    image: '/static/images/ministries/icons/worship.png',
+    imageTitle: 'worship',
+    title: 'Worship',
+    description: 'We believe in one God, Creator of all things, infinitely perfect and eternally existing in three persons: Father, Son, and Holy Spirit.',
+  },
+];
 
 class Ministries extends Component {
   componentDidMount() {
@@ -20,6 +95,8 @@ class Ministries extends Component {
   }
 
   render() {
+    // Mongo data not currently used - left for future use.
+    // eslint-disable-next-line no-unused-vars
     const ministryList = this.props.data.map(ministryObj => ministryObj.name);
 
     return (
@@ -33,17 +110,16 @@ class Ministries extends Component {
         </TitleBanner>
 
         <div className={styles.pageContent}>
-          {ministryList.map(ministryName => (
-            <div className={styles.ministryBox} key={ministryName}>
-              <Center vertical>{ministryName}</Center>
-            </div>
-          ))}
+          <TileDeck
+            data={ministriesList}
+          />
         </div>
       </div>
     );
   }
 }
 
+// Data not pulled through redux store/Mongo right now, just using static data. Potential use in future.
 Ministries.propTypes = {
   fetchData: PropTypes.func.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
Just put in some static data for the ministries page to use the same TileDeck as the Beliefs page. 
Left in the redux/mongo connection for now, but we can deal with that later.
Also awaiting description text for the ministries.