### PR TITLE
Pushing into our website (#135)

### DIFF
--- a/src/client/components/Footer.jsx
+++ b/src/client/components/Footer.jsx
@@ -10,7 +10,7 @@ const Footer = () => (
       <div className={styles.footerBorder}>
         <div className={`${styles.footerContainer} container footer`}>
           <div className={styles.copyright}>
-            <p>Copyright &copy; 1996-2019. Official website of <a href="/">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
+            <p>Copyright &copy; 1996-2020. Official website of <a href="/">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
           </div>
           <div className={styles.icons}>
             <a target="_blank" rel="noopener noreferrer" className={styles.footerLinks} href="https://www.facebook.com/gccphiladelphia/"><i className="fa fa-facebook fa-2x" /></a>

--- a/src/client/pages/Home.css
+++ b/src/client/pages/Home.css
@@ -213,6 +213,24 @@
     color: #979797;
     font-size: 16px;
     font-style: italic;
-    margin: 40px 0px;
+  }
+}
+
+.memoryVerseAssets {
+  margin-top: 30px;
+
+  .memoryLine {
+    border-top: 2px solid black;
+  }
+  .memoryText {
+    color: black;
+    font-size: 16px;
+    font-style: italic;
+    margin: 10px 0px 10px 0px;
+  }
+
+  .memoryAssetsLinks {
+    color: black;
+    margin: 0px 20px
   }
 }

--- a/test/__tests__/__snapshots__/publicPages.test.js.snap
+++ b/test/__tests__/__snapshots__/publicPages.test.js.snap
@@ -71,7 +71,7 @@ exports[`Public ServerTest renders 404 page 1`] = `
               <div class=\\"Footer__footerBorder\\">
                 <div class=\\"Footer__footerContainer container footer\\">
                   <div class=\\"Footer__copyright\\">
-                    <p>Copyright © 1996-2019. Official website of
+                    <p>Copyright © 1996-2020. Official website of
                       <a href=\\"/\\">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
                   </div>
                   <div class=\\"Footer__icons\\">
@@ -244,7 +244,7 @@ exports[`Public ServerTest renders Family Group page 1`] = `
               <div class=\\"Footer__footerBorder\\">
                 <div class=\\"Footer__footerContainer container footer\\">
                   <div class=\\"Footer__copyright\\">
-                    <p>Copyright © 1996-2019. Official website of
+                    <p>Copyright © 1996-2020. Official website of
                       <a href=\\"/\\">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
                   </div>
                   <div class=\\"Footer__icons\\">
@@ -458,8 +458,10 @@ exports[`Public ServerTest renders Home page 1`] = `
                           </div>
                         </td>
                         <td>
-                          <div class=\\"Home__subtitle\\">This Month: Loading
-                            <br/>Today: Loading</div>
+                          <div class=\\"Home__subtitle\\">GCC Reading Plan
+                            <br/>
+                            <a href=\\"https://drive.google.com/file/d/0B0tvne167dF0YUlXbDJzdUcwSUh2c0JyOTFheU5EbEQwelFJ/view\\">5x5x5 New Testament Reading Plan</a>
+                          </div>
                         </td>
                       </tr>
                     </tbody>
@@ -475,6 +477,12 @@ exports[`Public ServerTest renders Home page 1`] = `
               <div class=\\"Home__footerText\\">
                 <p class=\\"Lora__lora\\"></p>
               </div>
+              <div class=\\"Home__memoryVerseAssets\\">
+                <div class=\\"Home__memoryLine\\"></div>
+                <div class=\\"Home__memoryText\\">
+                  <p class=\\"Lora__lora\\">Click below for downloadable mobile backgrounds!</p>
+                </div>
+              </div>
             </div>
           </div>
         </main>
@@ -484,7 +492,7 @@ exports[`Public ServerTest renders Home page 1`] = `
               <div class=\\"Footer__footerBorder\\">
                 <div class=\\"Footer__footerContainer container footer\\">
                   <div class=\\"Footer__copyright\\">
-                    <p>Copyright © 1996-2019. Official website of
+                    <p>Copyright © 1996-2020. Official website of
                       <a href=\\"/\\">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
                   </div>
                   <div class=\\"Footer__icons\\">
@@ -642,7 +650,7 @@ exports[`Public ServerTest renders Welcome page 1`] = `
               <div class=\\"Footer__footerBorder\\">
                 <div class=\\"Footer__footerContainer container footer\\">
                   <div class=\\"Footer__copyright\\">
-                    <p>Copyright © 1996-2019. Official website of
+                    <p>Copyright © 1996-2020. Official website of
                       <a href=\\"/\\">Grace Covenant Church</a> in Philadelphia, PA. All rights reserved.</p>
                   </div>
                   <div class=\\"Footer__icons\\">


### PR DESCRIPTION
* Updating Footer (#125) (#128)

* Style Updates and Testing/Lint

* Staff Style Changes

* Lint

* Removed Scrolling

Windows machines were bugging out with really weird greyed out scroll bars.

* First round of review changes

* Card width, page bottom margin changes

* Events query corrected

* More Styling Changes

* Update Snapshots

* Memory verse on Contentful

* fix right overflow (#92)

* tile fixes (#93)

* Quick Style Changes

* TileDeck manually implemented

* Updated CROSSRoad text

* Update Events with without links

* Don't show events link if DNE

* Updating Travis Pipeline

* Giving page set up

* Fixed business value for PayPal

* Updated Giving Page

* Removed Console

* Renaming part one

* Renaming part 2

* PayPal String

* Updating Location Times (temp)

* Snapshot Update

* Changes to Services time and small margin changes

* Linting Changes

* Update Homepage Picture

* Updated Worship Picture (Homepage)

* changing pictures

* Updating Default Location and Times

* Updated Snapshot

* Updated Time Comparison Logic

* Formatting

* Sermons page setup

* Sermons 25 most recent API call

* Temp sermons page done

* New Background for Welcome page

* Welcome with a title

* Snapshot Updates

* Welcome Video Update

* reading plan (#113)

* Updated Snapshot

* Mobile navbar fix

* reading section styling (#115)

* Giving Paypal -> Subsplash

* Linting

* remove some mongodb stuff (#116)

* More remove mongo (#118)

* remove some mongodb stuff

* remove-mongodb

* reading plan bug (#119)

* Linking Mainline Site

* Snapshot and Lint

* Update Family Group Sign up Doc

* Update Test

* Update on Family Group Sign Up Forms

* Snapshot Tests

* reading plan bug + unrelated console warning

* Remove Twitter and Fix Facebook Link

* Update Snapshots

* Sunday Location Change

* Update snapshot

* Updating Crossraod FNL Time

* Bump webpack-bundle-analyzer from 2.13.1 to 3.3.2

Bumps [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) from 2.13.1 to 3.3.2.
- [Release notes](https://github.com/webpack-contrib/webpack-bundle-analyzer/releases)
- [Changelog](https://github.com/webpack-contrib/webpack-bundle-analyzer/blob/master/CHANGELOG.md)
- [Commits](https://github.com/webpack-contrib/webpack-bundle-analyzer/compare/v2.13.1...v3.3.2)

Signed-off-by: dependabot[bot] <support@github.com>

* Bump webpack-dev-server from 2.8.2 to 3.1.11

Bumps [webpack-dev-server](https://github.com/webpack/webpack-dev-server) from 2.8.2 to 3.1.11.
- [Release notes](https://github.com/webpack/webpack-dev-server/releases)
- [Changelog](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md)
- [Commits](https://github.com/webpack/webpack-dev-server/compare/v2.8.2...v3.1.11)

Signed-off-by: dependabot[bot] <support@github.com>

* Memory Verse and Reading Plan

Memory verse rework to provide digital assets and reading plan changes for 5x5x5 reading plans.

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>